### PR TITLE
[OMA-1245] :Navigating to PlayStore Failed after click on Video Ad on Real device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,14 @@
         android:name="android.hardware.location.gps"
         android:required="false" />
 
+    <queries>
+        <!-- Browser -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
This PR contains : 
* Quick fix for video ad click by adding manifest queries to apply new changes added to Android 11